### PR TITLE
Safety, Bacon doesn't like when reducing empty array

### DIFF
--- a/main.js
+++ b/main.js
@@ -514,6 +514,9 @@ var handleDelta = function(delta, options){
         typeof update.$source != "undefined" &&
         update.$source != "signalk-polar"
       ) {
+        if (!update.values.length) {
+          return;
+        }
         var points = update.values.reduce((acc, pathValue, options) => {
           //app.debug('found ' + pathValue.path)
           if (pathValue.path == "navigation.rateOfTurn") {


### PR DESCRIPTION
This removes a Bacon.js warning that was repeating multiple times per second on our system when signalk-polar received a meta delta.